### PR TITLE
EyeLink - fix wait_for_*

### DIFF
--- a/pygaze/_eyetracker/libeyelink.py
+++ b/pygaze/_eyetracker/libeyelink.py
@@ -648,6 +648,15 @@ class libeyelink(BaseEyeTracker):
 		
 		return (self.eventdetection,self.eventdetection,self.eventdetection)
 
+	def _get_eyelink_clock_async(self):
+		"""
+		Retrieve time differenece between tracker timestamps and 
+		current clock time upheld in the pygaze environment.
+
+		Returns:
+		The tracker time minus the clock time
+		"""
+		return pylink.getEYELINK().trackerTime() -  clock.time()
 
 	def wait_for_event(self, event):
 
@@ -661,10 +670,17 @@ class libeyelink(BaseEyeTracker):
 		if self.eye_used == None:
 			self.set_eye_used()
 		if self.eventdetection == 'native':
-			d = 0
-			while d != event:
+			# since the link buffer was not have been polled, old data has
+			# accumulated in the buffer -- so ignore events that are old:
+			t0 = clock.time() # time of call
+			while True:
 				d = pylink.getEYELINK().getNextData()
-			return pylink.getEYELINK().getFloatData()
+				if d == event:
+					float_data  = pylink.getEYELINK().getFloatData()
+					# corresponding clock_time
+					tc = float_data.getTime() - self._get_eyelink_clock_async()
+					if tc > t0:
+						return tc, float_data
 
 		if event == 5:
 			outcome = self.wait_for_saccade_start()
@@ -692,8 +708,8 @@ class libeyelink(BaseEyeTracker):
 		# EyeLink method
 		
 		if self.eventdetection == 'native':
-			d = self.wait_for_event(pylink.STARTSACC)
-			return d.getTime(), d.getStartGaze()
+			t,d = self.wait_for_event(pylink.STARTSACC)
+			return t, d.getStartGaze()
 		
 		
 		# # # # #
@@ -752,8 +768,8 @@ class libeyelink(BaseEyeTracker):
 		# EyeLink method
 		
 		if self.eventdetection == 'native':
-			d = self.wait_for_event(pylink.ENDSACC)
-			return d.getTime(), d.getStartGaze(), d.getEndGaze()
+			t,d = self.wait_for_event(pylink.ENDSACC)
+			return t, d.getStartGaze(), d.getEndGaze()
 		
 		
 		# # # # #
@@ -803,7 +819,6 @@ class libeyelink(BaseEyeTracker):
 	
 			return etime, spos, epos
 
-
 	def wait_for_fixation_start(self):
 
 		"""See pygaze._eyetracker.baseeyetracker.BaseEyeTracker"""
@@ -812,8 +827,8 @@ class libeyelink(BaseEyeTracker):
 		# EyeLink method
 		
 		if self.eventdetection == 'native':
-			d = self.wait_for_event(pylink.STARTFIX)
-			return d.getTime(), d.getStartGaze()
+			t,d = self.wait_for_event(pylink.STARTFIX)
+			return t, d.getTime(), d.getStartGaze()
 		
 		
 		# # # # #
@@ -862,8 +877,8 @@ class libeyelink(BaseEyeTracker):
 		# EyeLink method
 		
 		if self.eventdetection == 'native':
-			d = self.wait_for_event(pylink.ENDFIX)
-			return d.getTime(), d.getStartGaze()
+			t, d = self.wait_for_event(pylink.ENDFIX)
+			return t, d.getTime(), d.getStartGaze()
 		
 		
 		# # # # #
@@ -900,8 +915,8 @@ class libeyelink(BaseEyeTracker):
 		# EyeLink method
 		
 		if self.eventdetection == 'native':
-			d = self.wait_for_event(pylink.STARTBLINK)
-			return d.getTime()
+			t, d = self.wait_for_event(pylink.STARTBLINK)
+			return t, d.getTime()
 		
 		
 		# # # # #
@@ -926,7 +941,6 @@ class libeyelink(BaseEyeTracker):
 							# return timestamp of blink start
 							return t0
 
-
 	def wait_for_blink_end(self):
 
 		"""See pygaze._eyetracker.baseeyetracker.BaseEyeTracker"""
@@ -935,8 +949,8 @@ class libeyelink(BaseEyeTracker):
 		# EyeLink method
 		
 		if self.eventdetection == 'native':
-			d = self.wait_for_event(pylink.ENDBLINK)
-			return d.getTime()
+			t,d = self.wait_for_event(pylink.ENDBLINK)
+			return t
 		
 		
 		# # # # #

--- a/pygaze/_eyetracker/libeyelink.py
+++ b/pygaze/_eyetracker/libeyelink.py
@@ -652,6 +652,10 @@ class libeyelink(BaseEyeTracker):
 		"""
 		Retrieve time differenece between tracker timestamps and 
 		current clock time upheld in the pygaze environment.
+		
+		Note that this is not guaranteed to be a static time difference, the 
+		clocks might run at different speeds. Therefore you should consider 
+		running this function every time you utilize on this time difference.
 
 		Returns:
 		The tracker time minus the clock time


### PR DESCRIPTION
See comments for commit 778ac13 . Fixes wait_for_events


Please evaluate whether this was corrected properly! I haven't been able to test this, because I do not have straightforward acces to an Eyelink-tracker atm.


Notes:
 - This does NOT affect the non-native event detection, because pylinks `sample()` methods *will* always return the newest sample available, AFAIK.
 - These functions now return a timestamp that is in sync with `clock.time()` . This is consistent with the non-native event detection return value and consistent with the opensesame eyelink plugins. 
However, it might, without warnings, disrupt programs that presently make use of eyelink-time (though I can't imagine there will be any)

 - This also implements  a 'prrivate' function `_get_eyelink_clock_async()` . One could argue that you should omit the `_` and make it a function available to the user (this is what we did for opensesame).
However, the function might only make sense for the eyelink -- breaking the consistency of the class across trackers. Plus I honestly can't think of a good use case for it.

