### PR TITLE
made the threshold for blink deteciton variable

### DIFF
--- a/pygaze/_eyetracker/libeyelink.py
+++ b/pygaze/_eyetracker/libeyelink.py
@@ -70,6 +70,7 @@ class libeyelink(BaseEyeTracker):
 		data_file=settings.LOGFILENAME+".edf", fg_color=settings.FGC,
 		bg_color=settings.BGC, eventdetection=settings.EVENTDETECTION,
 		saccade_velocity_threshold=35, saccade_acceleration_threshold=9500,
+		blink_threshold=settings.BLINKTRESH,
 		force_drift_correct=True, pupil_size_mode=settings.EYELINKPUPILSIZEMODE,
 		**args):
 
@@ -108,6 +109,7 @@ class libeyelink(BaseEyeTracker):
 		self.recording = False
 		self.saccade_velocity_treshold = saccade_velocity_threshold
 		self.saccade_acceleration_treshold = saccade_acceleration_threshold
+		self.blink_threshold = blink_threshold
 		self.eye_used = None
 		self.left_eye = 0
 		self.right_eye = 1
@@ -930,7 +932,7 @@ class libeyelink(BaseEyeTracker):
 					# loop until a blink is determined, or a valid sample occurs
 					while not self.is_valid_sample(self.sample()):
 						# check if time has surpassed 150 ms
-						if clock.get_time()-t0 >= 150:
+						if clock.get_time()-t0 >= self.blink_threshold:
 							# return timestamp of blink start
 							return t0
 

--- a/pygaze/_eyetracker/libeyetribe.py
+++ b/pygaze/_eyetracker/libeyetribe.py
@@ -72,7 +72,8 @@ class EyeTribeTracker(BaseEyeTracker):
 
 	def __init__(self, display, logfile=settings.LOGFILE,
 		eventdetection=settings.EVENTDETECTION, saccade_velocity_threshold=35,
-		saccade_acceleration_threshold=9500, **args):
+		saccade_acceleration_threshold=9500, blink_threshold=settings.BLINKTHRESH,
+		**args):
 
 		"""Initializes the EyeTribeTracker object
 		
@@ -119,6 +120,7 @@ class EyeTribeTracker(BaseEyeTracker):
 		self.fixtimetresh = 100 # milliseconds; amount of time gaze has to linger within self.fixtresh to be marked as a fixation
 		self.spdtresh = saccade_velocity_threshold # degrees per second; saccade velocity threshold
 		self.accthresh = saccade_acceleration_threshold # degrees per second**2; saccade acceleration threshold
+		self.blinkthresh = blink_threshold # milliseconds; blink detection threshold used in PyGaze method
 		self.eventdetection = eventdetection
 		self.set_detection_type(self.eventdetection)
 		self.weightdist = 10 # weighted distance, used for determining whether a movement is due to measurement error (1 is ok, higher is more conservative and will result in only larger saccades to be detected)
@@ -796,8 +798,8 @@ class EyeTribeTracker(BaseEyeTracker):
 				t0 = clock.get_time()
 				# loop until a blink is determined, or a valid sample occurs
 				while not self.is_valid_sample(self.sample()):
-					# check if time has surpassed 150 ms
-					if clock.get_time()-t0 >= 150:
+					# check if time has surpassed BLINKTHRESH
+					if clock.get_time()-t0 >= self.blinkthresh:
 						# return timestamp of blink start
 						return t0
 		

--- a/pygaze/_eyetracker/libsmi.py
+++ b/pygaze/_eyetracker/libsmi.py
@@ -127,7 +127,8 @@ class SMItracker(BaseEyeTracker):
 	def __init__(self, display, ip='127.0.0.1', sendport=4444,
 		receiveport=5555, logfile=settings.LOGFILE,
 		eventdetection=settings.EVENTDETECTION, saccade_velocity_threshold=35,
-		saccade_acceleration_threshold=9500, **args):
+		saccade_acceleration_threshold=9500, blink_threshold=settings.BLINKTHRESH,
+		**args):
 
 		"""Initializes the SMItracker object
 		
@@ -184,6 +185,7 @@ class SMItracker(BaseEyeTracker):
 		self.fixtimetresh = 100 # milliseconds; amount of time gaze has to linger within self.fixtresh to be marked as a fixation
 		self.spdtresh = saccade_velocity_threshold # degrees per second; saccade velocity threshold
 		self.accthresh = saccade_acceleration_threshold # degrees per second**2; saccade acceleration threshold
+		self.blinkthresh = blink_threshold # milliseconds; blink detection threshold used in PyGaze method
 		self.eventdetection = eventdetection
 		self.set_detection_type(self.eventdetection)
 		self.weightdist = 10 # weighted distance, used for determining whether a movement is due to measurement error (1 is ok, higher is more conservative and will result in only larger saccades to be detected)
@@ -918,8 +920,8 @@ class SMItracker(BaseEyeTracker):
 				t0 = clock.get_time()
 				# loop until a blink is determined, or a valid sample occurs
 				while not self.is_valid_sample(self.sample()):
-					# check if time has surpassed 150 ms
-					if clock.get_time()-t0 >= 150:
+					# check if time has surpassed BLINKTHRESH
+					if clock.get_time()-t0 >= self.blinkthresh:
 						# return timestamp of blink start
 						return t0
 		

--- a/pygaze/_eyetracker/libtobii.py
+++ b/pygaze/_eyetracker/libtobii.py
@@ -97,7 +97,7 @@ class TobiiTracker(BaseEyeTracker):
 	
 	def __init__(self, display, logfile=settings.LOGFILE,
 		eventdetection=settings.EVENTDETECTION, saccade_velocity_threshold=35,
-		saccade_acceleration_threshold=9500, **args):
+		saccade_acceleration_threshold=9500, blink_threshold=settings.BLINKTHRESH, **args):
 		
 		"""Initializes a TobiiTracker instance
 		
@@ -153,6 +153,7 @@ class TobiiTracker(BaseEyeTracker):
 		self.fixtimetresh = 100 # milliseconds; amount of time gaze has to linger within self.fixtresh to be marked as a fixation
 		self.spdtresh = saccade_velocity_threshold # degrees per second; saccade velocity threshold
 		self.accthresh = saccade_acceleration_threshold # degrees per second**2; saccade acceleration threshold
+		self.blinkthresh = blink_threshold # milliseconds; blink detection threshold used in PyGaze method
 		self.eventdetection = eventdetection
 		self.set_detection_type(self.eventdetection)
 		self.weightdist = 10 # weighted distance, used for determining whether a movement is due to measurement error (1 is ok, higher is more conservative and will result in only larger saccades to be detected)
@@ -886,8 +887,8 @@ class TobiiTracker(BaseEyeTracker):
 				t0 = clock.get_time()
 				# loop until a blink is determined, or a valid sample occurs
 				while not self.is_valid_sample(self.sample()):
-					# check if time has surpassed 150 ms
-					if clock.get_time()-t0 >= 150:
+					# check if time has surpassed BLINKTHRESH
+					if clock.get_time()-t0 >= self.blinkthresh:
 						# return timestamp of blink start
 						return t0
 		

--- a/pygaze/defaults.py
+++ b/pygaze/defaults.py
@@ -59,6 +59,7 @@ JOYTIMEOUT = None # None for no timeout, or a value in milliseconds
 TRACKERTYPE = 'eyelink' # either 'smi', 'eyelink' or 'dummy' (NB: if DUMMYMODE is True, trackertype will be set to dummy automatically)
 SACCVELTHRESH = 35 # degrees per second, saccade velocity threshold
 SACCACCTHRESH = 9500 # degrees per second, saccade acceleration threshold
+BLINKTHRESH = 150 # milliseconds, blink detection threshold used in PyGaze method
 EVENTDETECTION = 'pygaze' # either 'pygaze' for PyGaze detection algorithms, or 'native' for manufacturer's event detection (if available)
 # EyeLink only
 EYELINKCALBEEP = True # Calibration beep with each jump


### PR DESCRIPTION
In tests we recognized, that the threshold for blink detection
set for the PyGaze method was to high to securely detect blinks.
As a fix for this problem I made this threshold a variable, which
can be changed within a `constants.py`. The default value is set to
be 150ms in `defaults.py`, as it was previously set within the code.
So for everyone not caring about this feature there should be no
difference in handling PyGaze, but everyone else now has the
possibility to change this threshold to what ever works best.