### PR TITLE
Fix setup and libeyelink regression

### DIFF
--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-python-pygaze (0.6.0~a8-ubuntu1) wily; urgency=medium
+python-pygaze (0.6.0~a9-ubuntu1) wily; urgency=medium
 
   * Prerelease update
 

--- a/debian/changelog
+++ b/debian/changelog
@@ -1,4 +1,4 @@
-python-pygaze (0.6.0~a9-ubuntu1) wily; urgency=medium
+python-pygaze (0.6.0~a10-ubuntu1) wily; urgency=medium
 
   * Prerelease update
 

--- a/pygaze/__init__.py
+++ b/pygaze/__init__.py
@@ -23,7 +23,7 @@ from pygaze.settings import settings
 from distutils.version import StrictVersion
 import os
 
-__version__ = version = u'0.6.0a9'
+__version__ = version = u'0.6.0a10'
 strict_version = StrictVersion(__version__)
 # The version without the prerelease (if any): e.g. 3.0.0
 main_version = u'.'.join([str(i) for i in strict_version.version])

--- a/pygaze/__init__.py
+++ b/pygaze/__init__.py
@@ -23,7 +23,7 @@ from pygaze.settings import settings
 from distutils.version import StrictVersion
 import os
 
-__version__ = version = u'0.6.0a8'
+__version__ = version = u'0.6.0a9'
 strict_version = StrictVersion(__version__)
 # The version without the prerelease (if any): e.g. 3.0.0
 main_version = u'.'.join([str(i) for i in strict_version.version])

--- a/pygaze/_eyetracker/libeyelink.py
+++ b/pygaze/_eyetracker/libeyelink.py
@@ -71,7 +71,7 @@ class libeyelink(BaseEyeTracker):
 		data_file=settings.LOGFILENAME+".edf", fg_color=settings.FGC,
 		bg_color=settings.BGC, eventdetection=settings.EVENTDETECTION,
 		saccade_velocity_threshold=35, saccade_acceleration_threshold=9500,
-		blink_threshold=settings.BLINKTRESH,
+		blink_threshold=settings.BLINKTHRESH,
 		force_drift_correct=True, pupil_size_mode=settings.EYELINKPUPILSIZEMODE,
 		**args):
 

--- a/setup.py
+++ b/setup.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python3
+#!/usr/bin/env python
 
 """
 This file is part of qnotero.


### PR DESCRIPTION
Two important fixes, one as described in #54, and a regression in `libeyelink` introduced by @scattenlaeufer in #50.

The regression is worrying, because it results from a simple typo (`BLINKTRESH` instead of `BLINKTHRESH`). This means that this commit was (partly) blind-coded, and *not tested at all*--neither when sent as a pull request, nor when merged. This really shouldn't happen.