### PR TITLE
fixed fixation detection for tobii tracker

### DIFF
--- a/pygaze/_eyetracker/libtobii.py
+++ b/pygaze/_eyetracker/libtobii.py
@@ -1011,7 +1011,7 @@ class TobiiTracker(BaseEyeTracker):
 					# check if fixation time threshold has been surpassed
 					if t1 - t0 >= self.fixtimetresh:
 						# return time and starting position
-						return t1, spos
+						return t0, spos
 
 
 	def wait_for_saccade_end(self):


### PR DESCRIPTION
Now not the time of the fixation detection, but the time of the fixation
start is provided by wait_for_fixation_start(). This fixes #45