### PR TITLE
pygaze_init: don't disable controls for saccade velocity and acceleration for EyeLink

### DIFF
--- a/opensesame_plugins/pygaze_init/pygaze_init.py
+++ b/opensesame_plugins/pygaze_init/pygaze_init.py
@@ -281,8 +281,6 @@ class qtpygaze_init(pygaze_init, qtautoplugin):
 		eyelink = self.var.tracker_type == u'EyeLink'
 		self.checkbox_eyelink_force_drift_correct.setEnabled(eyelink)
 		self.combobox_eyelink_pupil_size_mode.setEnabled(eyelink)
-		self.spinbox_sacc_acc_thr.setDisabled(eyelink)
-		self.spinbox_sacc_vel_thr.setDisabled(eyelink)
 		if eyelink:
 			try:
 				import pylink

--- a/pygaze/__init__.py
+++ b/pygaze/__init__.py
@@ -25,7 +25,7 @@ from distutils.version import StrictVersion
 import sys
 import os
 
-__version__ = version = u'0.6.0a18'
+__version__ = version = u'0.6.0a19'
 strict_version = StrictVersion(__version__)
 # The version without the prerelease (if any): e.g. 3.0.0
 main_version = u'.'.join([str(i) for i in strict_version.version])


### PR DESCRIPTION
I noticed that, when selecting the EyeLink in the `pygaze_init` plugin for OpenSesame, the options for the saccade acceleration and velocity thresholds were disabled. I don't see any reason for this, so I changed it. However, maybe I forgot why I did this in the first place--so please check!