### PR TITLE
In validation of Tobii calibration make text disappear after button press

### DIFF
--- a/pygaze/_eyetracker/libtobii.py
+++ b/pygaze/_eyetracker/libtobii.py
@@ -549,6 +549,7 @@ class TobiiProTracker(BaseEyeTracker):
             self.kb.get_key(keylist=['space'], flush=True, timeout=None)
 
             # # show fixation
+            self.screen.clear()
             self.screen.draw_fixation(fixtype='dot', colour=(255, 255, 255))
             self.disp.fill(self.screen)
             self.disp.show()


### PR DESCRIPTION
This makes the instruction during the noise calibration disappear after
the space bar is pressed, so there is a visual cue the input was
registered and noise calibration as stared.