### PR TITLE
Fix lazy-loading for OpenSesame 3.3

### DIFF
--- a/opensesame_plugins/pygaze_drift_correct/pygaze_drift_correct.py
+++ b/opensesame_plugins/pygaze_drift_correct/pygaze_drift_correct.py
@@ -113,6 +113,10 @@ class qtpygaze_drift_correct(pygaze_drift_correct, qtautoplugin):
 
 		pygaze_drift_correct.__init__(self, name, experiment, script)
 		qtautoplugin.__init__(self, __file__)
+
+	def init_edit_widget(self):
+
+		qtautoplugin.init_edit_widget(self)
 		self.custom_interactions()
 
 	def apply_edit_changes(self):

--- a/opensesame_plugins/pygaze_init/pygaze_init.py
+++ b/opensesame_plugins/pygaze_init/pygaze_init.py
@@ -67,8 +67,6 @@ class pygaze_init(item):
 		self.var.tobiiglasses_address = u'192.168.71.50'
 		self.var.tobiiglasses_udpport = 49152
 
-
-
 	def close(self):
 
 		"""
@@ -251,6 +249,11 @@ class qtpygaze_init(pygaze_init, qtautoplugin):
 
 		pygaze_init.__init__(self, name, experiment, script)
 		qtautoplugin.__init__(self, __file__)
+
+	def init_edit_widget(self):
+
+		qtautoplugin.init_edit_widget(self)
+		self.custom_interactions()
 		self.text_pygaze_version.setText(
 			u'<small>PyGaze version %s</small>' % pygaze.version)
 
@@ -312,4 +315,3 @@ class qtpygaze_init(pygaze_init, qtautoplugin):
 				self.text_eyelink_pylink_check.hide()
 		else:
 			self.text_eyelink_pylink_check.hide()
-


### PR DESCRIPTION
In OpenSesame 3.3, the controls of items are not immediately loaded, to improve the responsiveness of the UI. This fix is necessary to accommodate that for the PyGaze plugins.

Would it be possible to merge this fix and push it to PyPi as 0.6.5?