### PR TITLE
draw_text parametrizable wrapWidth

### DIFF
--- a/pygaze/_screen/psychopyscreen.py
+++ b/pygaze/_screen/psychopyscreen.py
@@ -505,7 +505,7 @@ class PsychoPyScreen(BaseScreen):
 
     def draw_text(self, text="text", colour=None, color=None, pos=None, \
             centre=None, center=None, font="mono", fontsize=12, \
-            antialias=True):
+            antialias=True, wrapWidth=None):
 
         """Draws a text on the screen
         
@@ -571,7 +571,7 @@ class PsychoPyScreen(BaseScreen):
         self.screen.append(TextStim(pygaze.expdisplay, text=str(text), \
             font=font, pos=pos, color=colour, height=fontsize, \
             antialias=antialias, alignHoriz=align, \
-            fontFiles=pygaze.FONTFILES, wrapWidth=None))
+            fontFiles=pygaze.FONTFILES, wrapWidth=self.dispsize[0] if wrapWidth is None else wrapWidth))
         # PsychoPy deprecated "alignHoriz", but in version 3.2.4 (and maybe
         # also others, who knows?) its replacements "alignText" and
         # "anchorHoriz" are unknown keyword arguments to __init__. Yet,


### PR DESCRIPTION
`draw_text` makes an implicit assumption, that the `wrapWidth` should be loaded from the defaults (500px). This can not be fixed with the current parameter list. This PR simply adds a wrapWidth parameter, which defaults to None. If that is the case, the whole display screen width is used (basically no wrap). If it is supplied, it is passed on to `TextStim`.

You may want to omit the defaulting to display width, which will make it default to 500px again. For our purposes, however, display width was the more sensible solution.