### PR TITLE
pylink 2.1 __version__ bugfix

### DIFF
--- a/pygaze/_eyetracker/eyelinkgraphics.py
+++ b/pygaze/_eyetracker/eyelinkgraphics.py
@@ -101,7 +101,7 @@ class EyelinkGraphics(custom_display):
             pl_version = pylink.__version__.split(".")
         else:
             # in pylink 2.1 pylink.__version__ is a module
-            pl_version = pylink.__version__.__version__
+            pl_version = pylink.__version__.__version__.split(".")
             
         if int(pl_version[0]) > 1 or int(pl_version[1]) >= 11:
             self.scale_lines_in_eye_image = False

--- a/pygaze/_eyetracker/eyelinkgraphics.py
+++ b/pygaze/_eyetracker/eyelinkgraphics.py
@@ -97,7 +97,12 @@ class EyelinkGraphics(custom_display):
         # pylink 1.1.0.5 (tested on Python 2.7) but not on pylink 1.11.0.0
         # (tested on Python 3.6). I'm not sure when this change happened, so
         # it's quite likely we'll have to update the minor version used here.
-        pl_version = pylink.__version__.split(".")
+        if type(pylink.__version__) == str:
+            pl_version = pylink.__version__.split(".")
+        else:
+            # in pylink 2.1 pylink.__version__ is a module
+            pl_version = pylink.__version__.__version__
+            
         if int(pl_version[0]) > 1 or int(pl_version[1]) >= 11:
             self.scale_lines_in_eye_image = False
         else:


### PR DESCRIPTION
I  recently got a new eyelink1000+ that was delivered with pylink 2.1. 

In this pylink version, `pylink.__version__` is a module (not a string anymore) containing `pylink.__version__.__version__` with the version number as str.
This simple fix solved an issue we had so far - I will perform some further testing tomorrow when I have access to the eye tracker again.

Cheers, Bene

PS: The fix is now from memory, I hope I didn't introduce a syntax error, but the gist of what it does should be quite obvious