### PR TITLE
Various fixes for OpenGaze / GazePoint

### DIFF
--- a/pygaze/__init__.py
+++ b/pygaze/__init__.py
@@ -25,7 +25,7 @@ from distutils.version import StrictVersion
 import sys
 import os
 
-__version__ = version = "0.7.4"
+__version__ = version = "0.7.5a1"
 strict_version = StrictVersion(__version__)
 # The version without the prerelease (if any): e.g. 3.0.0
 main_version = ".".join([str(i) for i in strict_version.version])

--- a/pygaze/__init__.py
+++ b/pygaze/__init__.py
@@ -25,7 +25,7 @@ from distutils.version import StrictVersion
 import sys
 import os
 
-__version__ = version = "0.7.5a1"
+__version__ = version = "0.7.5a2"
 strict_version = StrictVersion(__version__)
 # The version without the prerelease (if any): e.g. 3.0.0
 main_version = ".".join([str(i) for i in strict_version.version])

--- a/pygaze/_eyetracker/libopengaze.py
+++ b/pygaze/_eyetracker/libopengaze.py
@@ -237,6 +237,9 @@ class OpenGazeTracker(BaseEyeTracker):
         # wait for keyboard input
         key, keytime = self.kb.get_key(keylist=['q', 's', 'space'],
             timeout=None, flush=True)
+        self.screen.clear()
+        self.disp.fill(self.screen)
+        self.disp.show()
         if key == 's':
             return True
         if key == 'q':

--- a/pygaze/_eyetracker/opengaze.py
+++ b/pygaze/_eyetracker/opengaze.py
@@ -174,10 +174,10 @@ class OpenGazeTracker:
         self._inthread.start()
         self._debug_print("Starting the outgoing thread.")
         self._outthread.start()
-        
-        # SET UP LOGGING
         # Wait for a bit to allow the Threads to start.
-        time.sleep(0.5)
+        while (not self._logthread.is_alive() or not self._inthread.is_alive()
+               or not self._outthread.is_alive()):
+            time.sleep(.005)
         # Enable the tracker to send ALL the things.
         self.enable_send_counter(True)
         self.enable_send_cursor(True)

--- a/pygaze/_eyetracker/opengaze.py
+++ b/pygaze/_eyetracker/opengaze.py
@@ -192,8 +192,6 @@ class OpenGazeTracker:
         self.enable_send_time(True)
         self.enable_send_time_tick(True)
         self.enable_send_user_data(True)
-        # Reset the user-defined variable.
-        self.user_data("0")
 
     
     def calibrate(self):
@@ -262,14 +260,7 @@ class OpenGazeTracker:
         DATA!
         """
 
-        # Set the user-defined value.
-        i = copy.copy(self._logcounter)
         self.user_data(message)
-        # Wait until a single sample is logged.
-        while self._logcounter <= i:
-            time.sleep(0.0001)
-        # Reset the user-defined value.
-        self.user_data("0")
     
     def start_recording(self):
         
@@ -1154,15 +1145,11 @@ class OpenGazeTracker:
         """Set the value of the user data field for embedding custom data
         into the data stream. The user data value should be a string.
         """
-
-        # Send the message (returns after the Server acknowledges receipt).
-        acknowledged, timeout = self._send_message('SET', \
-            'USER_DATA', \
-            values=[('VALUE', str(value))], \
-            wait_for_acknowledgement=True)
         
-        # Return a success Boolean.
-        return acknowledged and (timeout==False)
+        acknowledged, timeout = self._send_message(
+            'SET', 'USER_DATA', values=[('VALUE', str(value)), ('DUR', 1)],
+            wait_for_acknowledgement=True)
+        return acknowledged and not timeout
     
     def tracker_display(self, state):
         

--- a/pygaze/_eyetracker/opengaze.py
+++ b/pygaze/_eyetracker/opengaze.py
@@ -371,9 +371,6 @@ class OpenGazeTracker:
         
         while self._connected.is_set():
 
-            # Lock the socket to prevent other Threads from simultaneously
-            # accessing it.
-            time.sleep(0.005)
             # Get new messages from the OpenGaze Server.
             timeout = False
             with self._socklock:
@@ -448,7 +445,7 @@ class OpenGazeTracker:
                         self._incoming[command][msgdict['ID']]))
                 # Unlock the incoming dict again.
                 self._inlock.release()
-        
+            time.sleep(0.005)  # throttle to allow outgoing thread to work
         self._debug_print("Incoming Thread ended.")
         return
 


### PR DESCRIPTION
This PR contains various fixes for OpenGaze / GazePoint. This has been tested with a GazePoint 3 eye tracker on Windows 10 and 11.

- The ingoing and outgoing threads were blocking each other, resulting in extremely long delays (> 1 min) when initializing the eye tracker and calibration. For now, I fixed this simply by throttling the incoming thread with a short delay. A proper solution would be to merge the ingoing and outgoing threads into a single thread; after all, they're using the same socket and therefore they cannot operate in parallel anyway, and only end up blocking each other.
- Calibration for monocular recording is fixed
- `pupil_size()` is fixed (returned distance to camera instead of pupil size)
- USER_DATA is set for one frame using the DUR parameter introduced in OpenGaze 2.4, as opposed to clearing it explicitly (which seemed to cause message dropping)

A remaining issue (not a bug but bothersome nonetheless) is that the number of log messages is limited to one per sample, because they ride on the `USER_DATA` field. This means that the user cannot send, for example, lots of messages with experimental variables to the eye tracker for later analysis. I'll open a separate issue to discuss how to improve this.