### PR TITLE
Fix for OpenGaze / GazePoint

### DIFF
--- a/pygaze/__init__.py
+++ b/pygaze/__init__.py
@@ -25,7 +25,7 @@ from distutils.version import StrictVersion
 import sys
 import os
 
-__version__ = version = "0.7.5a5"
+__version__ = version = "0.7.6a1"
 strict_version = StrictVersion(__version__)
 # The version without the prerelease (if any): e.g. 3.0.0
 main_version = ".".join([str(i) for i in strict_version.version])

--- a/pygaze/_eyetracker/opengaze.py
+++ b/pygaze/_eyetracker/opengaze.py
@@ -391,8 +391,10 @@ class OpenGazeTracker:
 
             self._debug_print(r"Raw instring: {}".format(instring))
 
-            # Split the messages (they are separated by '\r\n').
-            messages = instring.split('\r\n')
+            # Split the messages. These should be are separated by '\r\n', but
+            # the safest way to split them is to split them by any newline
+            # character while ignoring the empty messages.
+            messages = [msg for msg in instring.splitlines() if msg.strip()]
 
             # Check if there is currently an unfinished message.
             if self._unfinished:


### PR DESCRIPTION
This is a simple but crucial fix for OpenGaze, resulting [this forum report](https://forum.cogsci.nl/discussion/8360/gazepoint-opensesame-lxml-etree-xmlsyntaxerror-extracontent). Can you release this as 0.7.6 on PyPi?